### PR TITLE
Improve handling of empty actual data

### DIFF
--- a/dtspec/api.py
+++ b/dtspec/api.py
@@ -255,14 +255,35 @@ class Api:
         """
         Used to load data containing the actual results to be compared with expectations
 
-        Expecting a json object with keys that are the names of data targets
-        and values that are an array of records.  Each record is a json object
-        with keys that are column names and values that are the record column values.
+        Expecting a json object with keys that are the names of data targets and the
+        values contain the individual records for the target, and description of the
+        columns present in the target.
+
+        Example::
+
+            {
+                "students": {
+                    "records": [
+                        {"id": "1", "name": "Buffy", "school_id": "1"},
+                        {"id": "2", "name": "Willow", "school_id": "1"},
+                    ],
+                    "columns": ["id", "name", "school_id"]
+                },
+                "schools": {
+                    "records": [
+                        {"id": "1", "name": "Sunnydale"}
+                    ],
+                    "columns": ["id", "name"]
+                }
+            }
         """
 
-        for target, records in actuals_json.items():
+        for target, target_data in actuals_json.items():
+            records = target_data["records"]
+            columns = target_data.get("columns", None)
+
             print(f"Loading actuals for target {target}")
-            self.spec["targets"][target].load_actual(records)
+            self.spec["targets"][target].load_actual(records, columns=columns)
 
     def assert_expectations(self):
         "Runs all of the assertions defined in the spec against the actual data"

--- a/tests/test_api_features.py
+++ b/tests/test_api_features.py
@@ -27,7 +27,10 @@ def serialize_actuals(actuals):
     "Converts Pandas dataframe results into form needed to load dtspec api actuals"
 
     return {
-        target_name: json.loads(dataframe.astype(str).to_json(orient="records"))
+        target_name: {
+            "records": json.loads(dataframe.astype(str).to_json(orient="records")),
+            "columns": list(dataframe.columns),
+        }
         for target_name, dataframe in actuals.items()
     }
 

--- a/tests/test_misc_features.py
+++ b/tests/test_misc_features.py
@@ -34,7 +34,10 @@ def serialize_actuals(actuals):
         return str_df.combine(nulls_df, replace_nulls)
 
     return {
-        target_name: json.loads(stringify_pd(dataframe).to_json(orient="records"))
+        target_name: {
+            "records": json.loads(stringify_pd(dataframe).to_json(orient="records")),
+            "columns": list(dataframe.columns),
+        }
         for target_name, dataframe in actuals.items()
     }
 

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -89,3 +89,22 @@ def test_raises_error_if_raw_id_not_found(simple_target, simple_data):
     bad_data[1]["id"] = 123456789
     with pytest.raises(dtspec.core.UnableToFindNamedIdError):
         simple_target.load_actual(bad_data)
+
+
+def test_empty_data_can_be_loaded_with_columns_specified(simple_target):
+    simple_target.load_actual([], columns=["id", "first_name"])
+
+    actual = simple_target.data.drop(columns="__dtspec_case__")
+    expected = markdown_to_df(
+        """
+        | id   | first_name |
+        | -    | -          |
+        """
+    )
+
+    assert_frame_equal(actual, expected)
+
+
+def test_raises_if_data_is_empty_wo_columns_specified(simple_target):
+    with pytest.raises(dtspec.core.EmptyDataNoColumnsError):
+        simple_target.load_actual([])


### PR DESCRIPTION
Error messaging was very cryptic when a resultant dataset
was empty (and coming from Python, not dtspec).  This change
handles this case better, but does make a breaking change to
the API responsible for loading actuals.